### PR TITLE
Support for using settings.conf cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ You can also specify the path to a CFG file:
 ```
 ./wanted.py --type backup --cfg /your/path/cfg --file /volume1/Public/backup.txt
 ```
+Also, you can use your settings.conf from couchpotato:
+```
+./wanted.py --type backup --cfg /your/path/.couchpotato/settings.conf --file /volume1/Public/backup.txt
+```
 
 ###### Backup
 To create a backup of your wanted movies, run the script passing in the options "backup" and the full path/name of the backup file you want to create

--- a/couch.cfg
+++ b/couch.cfg
@@ -4,8 +4,8 @@ host = localhost
 # The port for couchpotato
 port = 5050
 # Your API key here. See README for more information
-apikey = 
-# Set to 'yes' if you want to enable ssl connection (HTTPS)
-ssl = no
+api_key =
+# Set to 'True' if you want to enable ssl connection (HTTPS)
+ssl = False
 # Your web root for couchpotato. Empty value is OK
-web_root =
+url_base =

--- a/wanted.py
+++ b/wanted.py
@@ -87,6 +87,13 @@ def process(type, backup = None):
     else:
         protocol = "http://"
     
+    # Add '/' to beginning of web_root if missing
+    if web_root and not web_root[0] == '/':
+        web_root = '/' + web_root
+    # Remove '/' from end of web_root if present
+    if web_root and web_root[-1] == '/':
+        web_root = web_root[:-1]
+
     # The base URL
     baseurl = protocol + host + ":" + str(port) + web_root + "/api/" + apikey + "/"
     if type == "backup":


### PR DESCRIPTION
Please note that I changed some of the couch.cfg variable names so it matches settings.conf. If you want to use the couch.cfg and have a previous version you're using it's  important that you update your cfg with the new variable names.
I would recommend to use the settings.conf instead though, since then you don't have to enter anything manually.