### PR TITLE
Add function to clear the "Managed" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ It will restore the qualities, but if you reinstalled couchpotato only the defau
 If this is the case you'll need to recreate those and manually edit these in the wanted list.
 In case you worry about auto-snatch with the wrong quality etc (not default) I suggest setting your downloader to "manual" to prevent auto-snatching, before running the restore. Take the downloader out of "manual" mode once you are comfortable all has been restored correctly.
 
+###### Clear
+This will delete all movies in your managed list.
+```
+./wanted.py --type clear
+```
+
 ###### Delete
 This will delete all movies in your wanted list.
 ```

--- a/wanted.py
+++ b/wanted.py
@@ -70,6 +70,12 @@ def listDone(baseurl):
     result = apiCall(url)
     return result
 
+def listLimitedDone(baseurl):
+    api_call = "movie.list/?status=manage&limit_offset=50"
+    url = baseurl + api_call
+    result = apiCall(url)
+    return result
+
 def process(type, backup = None):
     config = ConfigParser.ConfigParser()
     if args.cfg:

--- a/wanted.py
+++ b/wanted.py
@@ -180,6 +180,20 @@ def process(type, backup = None):
             url = baseurl + api_call
             result = apiCall(url)
 
+    elif type == "clear":
+        result = listLimitedDone(baseurl)
+        print "Clearing Movie Library..."
+        if not result['empty']:
+            while not result['empty']:
+                for item in result["movies"]:
+                    print "Clearing movie '%s' from Library" % item["title"]
+                    api_call = "movie.delete/?delete_from=manage&id=%s" % item["_id"]
+                    url = baseurl + api_call
+                    apiCall(url, verbose = False)
+                result = listLimitedDone(baseurl)
+        else:
+            print "No movies in Library to clear"
+
     elif type == "delete":
         result = listWanted(baseurl)
         if result['total'] > 0:
@@ -233,7 +247,7 @@ def process(type, backup = None):
 parser = argparse.ArgumentParser(description='Backup/Restore/Delete/Export Couchpotato wanted/library list',
                                 formatter_class=argparse.RawTextHelpFormatter)
 # Require this option
-parser.add_argument('--type', metavar='backup/restore/delete/add/export', choices=['backup', 'restore', 'delete', 'add', 'export'],
+parser.add_argument('--type', metavar='backup/restore/delete/add/export/clear', choices=['backup', 'restore', 'delete', 'add', 'export', 'clear'],
         required=True, help='''backup: Writes the wanted movies to file.
 restore: Adds wanted movies from file.
 delete: Delete all your wanted movies


### PR DESCRIPTION
I found an issue where CouchPotato had created thousands (50k+) of duplicate entries. This seemed the most sensible way to clear these without deleting the database entirely.

The reason for the Limited listing is performance and memory. CouchPotato ended up using about 4.3GB of memory on what was originally a 1GB VM when doing the api_call without limits. CP-BackupTool used a bit less at about 2.2GB. With a limited api_call, the memory needs are instead negligible.

Please let me know if there are any conventions I am not following.

Thank you.
Changes compared to #31 
Fixed infinite loop by minor refactoring, using the api-provided "empty" bool instead of using the "total".